### PR TITLE
Sets PRIVATE_NETWORK_IP properly under MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hubs Compose
 
 Hubs Compose is a Docker Compose setup than can be used to orchestrate all the
-services used by Hubs for local development.[^1]
+services used by Hubs for local development.[^1]  It runs on Windows, MacOS or Linux.
 
 [^1]: This is not a production-ready setup.  It does not account for
 security or scalability.  Additionally the permissions files were generated for
@@ -43,7 +43,7 @@ certificates, you can visit https://hubs.local:4000 from your browser.
 ### Initial Setup
 
 1. [Install Docker Compose](https://docs.docker.com/compose/install)
-2. [Install Mutagen](https://mutagen.io/documentation/introduction/installation)
+2. [Install Mutagen](https://mutagen.io/documentation/introduction/installation) [The scripts start the Mutagen daemon, so it is *not* necessary to configure your system to automatically start on boot.]
 3. [Install Mutagen Compose](https://github.com/mutagen-io/mutagen-compose#system-requirements)
   - Ensure that the version of Mutagen Compose you're installing matches the version of Mutagen that you installed. (If you install the latest versions at the same time, they will "match".)
 4. Add these entries to your hosts file:
@@ -78,13 +78,21 @@ means visiting these links in your web browser and following the prompts:
 * [Dialog](https://hubs.local:4443)
 * [Spoke](https://hubs.local:9090)
 * [Hubs Admin](https://hubs.local:8989)
-* [Hubs Client](https://hubs.local:8080)
-* [Reticulum](https://hubs.local:4000)
+* [Hubs Client](https://hubs.local:8080) Used to connect to Hubs rooms
+* [Reticulum](https://hubs.local:4000) Used for the Admin Panel and Spoke
+
+### Logging In
+
+See [the QuickStart guide](./guides/quick-start.md) to log in without having SMTP functional.
 
 ### Admin panel access
 
-To connect to the admin panel you will need to manually
+To connect to the admin panel you will need to `cd` to `services/reticulum` and manually
 [promote an account to admin](https://github.com/Hubs-Foundation/reticulum#6-creating-an-admin-user).
+
+Access the admin panel at https://hubs.local:4000/admin. You may need to re-accept your magic-link email in your reticulum container's logs.
+
+Access Spoke at https://hubs.local:4000/spoke
 
 ## Troubleshooting
 

--- a/bin/down
+++ b/bin/down
@@ -1,8 +1,12 @@
 #!/bin/bash
 basedir=$(dirname "$0")/..
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    IP_ADDR=$(ifconfig -l | xargs -n1 ipconfig getifaddr)
+    IP_ADDR=$(hostname -i | cut -f1)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    IP_ADDR=$(ip route get 1 | awk '{print $NF;exit}')
+    IP_ADDR=$(ipconfig getifaddr en1)
+    if [[ -z "$IP_ADDR" ]]; then
+      IP_ADDR=$(ipconfig getifaddr en0)
+    fi
 fi
-PRIVATE_NETWORK_IP=${ADDR} mutagen-compose -f "$basedir"/docker-compose.yml down
+PRIVATE_NETWORK_IP=${IP_ADDR} mutagen-compose -f "$basedir"/docker-compose.yml down

--- a/bin/init
+++ b/bin/init
@@ -6,26 +6,36 @@ prefix='\n\033[1;37m'
 suffix='\033[0m\n'
 
 servicesdir=$basedir/services
-echo -e ${prefix}Cloning source repositories$suffix
+echo -e "${prefix}Cloning source repositories$suffix"
 git clone https://github.com/Hubs-Foundation/reticulum.git "$servicesdir"/reticulum
 git clone https://github.com/Hubs-Foundation/dialog.git "$servicesdir"/dialog
 git clone https://github.com/Hubs-Foundation/hubs.git "$servicesdir"/hubs
 git clone https://github.com/Hubs-Foundation/Spoke.git "$servicesdir"/spoke
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    IP_ADDR=$(hostname -i | cut -f1)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    IP_ADDR=$(ipconfig getifaddr en1)
+    if [[ -z "$IP_ADDR" ]]; then
+      IP_ADDR=$(ipconfig getifaddr en0)
+    fi
+fi
+export PRIVATE_NETWORK_IP=$IP_ADDR
+
 composefile=$basedir/docker-compose.yml
-echo -e ${prefix}Initializing Reticulum$suffix &&
+echo -e "${prefix}Initializing Reticulum$suffix" &&
 docker-compose -f "$composefile" build reticulum &&
 mutagen-compose -f "$composefile" run --rm reticulum sh -c 'trapped-mix do deps.get, deps.compile, ecto.create' &&
-echo -e ${prefix}Initializing Dialog$suffix &&
+echo -e "${prefix}Initializing Dialog$suffix" &&
 docker-compose -f "$composefile" build dialog &&
 mutagen-compose -f "$composefile" run --rm dialog conditional-npm-ci &&
-echo -e ${prefix}Initializing Hubs Admin$suffix &&
+echo -e "${prefix}Initializing Hubs Admin$suffix" &&
 docker-compose -f "$composefile" build hubs-admin &&
 mutagen-compose -f "$composefile" run --rm hubs-admin conditional-npm-ci &&
-echo -e ${prefix}Initializing Hubs Client$suffix &&
+echo -e "${prefix}Initializing Hubs Client$suffix" &&
 docker-compose -f "$composefile" build hubs-client &&
 mutagen-compose -f "$composefile" run --rm hubs-client conditional-npm-ci &&
-echo -e ${prefix}Initializing Spoke$suffix &&
+echo -e "${prefix}Initializing Spoke$suffix" &&
 mutagen-compose -f "$composefile" run --rm spoke yarn install
 
 code=$?

--- a/bin/reset
+++ b/bin/reset
@@ -1,6 +1,16 @@
 #!/bin/bash
 basedir=$(readlink -f "$(dirname "$0")"/..)
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    IP_ADDR=$(hostname -i | cut -f1)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    IP_ADDR=$(ipconfig getifaddr en1)
+    if [[ -z "$IP_ADDR" ]]; then
+      IP_ADDR=$(ipconfig getifaddr en0)
+    fi
+fi
+export PRIVATE_NETWORK_IP=$IP_ADDR
+
 mutagen-compose -f "$basedir"/docker-compose.yml down --volumes --rmi local &&
 rm -rf "$basedir"/services/reticulum/deps &&
 "$basedir"/bin/init

--- a/bin/up
+++ b/bin/up
@@ -10,8 +10,11 @@ echo -e ${prefix}The mutagen daemon will stay running until you stop it manually
 echo -e ${prefix}Running mutagen-compose...$suffix
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    IP_ADDR=$(ifconfig -l | xargs -n1 ipconfig getifaddr)
+    IP_ADDR=$(hostname -i | cut -f1)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    IP_ADDR=$(ip route get 1 | awk '{print $NF;exit}')
+    IP_ADDR=$(ipconfig getifaddr en1)
+    if [[ -z "$IP_ADDR" ]]; then
+      IP_ADDR=$(ipconfig getifaddr en0)
+    fi
 fi
-PRIVATE_NETWORK_IP=${ADDR} mutagen-compose -f "$basedir"/docker-compose.yml up --build --detach
+PRIVATE_NETWORK_IP=${IP_ADDR} mutagen-compose -f "$basedir"/docker-compose.yml up --build --detach

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     environment:


### PR DESCRIPTION
On my Debian 12 server, the new code sets PRIVATE_NETWORK_IP properly, but I'm not certain it works for every distro.

Also updates documentation.  We might want to copy in the info from the QuickStart Guide and https://github.com/Hubs-Foundation/reticulum#6-creating-an-admin-user instead of just referencing it.